### PR TITLE
These changes address ens2nc_aq crashes occurring with the intel

### DIFF
--- a/ens2nc/ens2nc_aq.for
+++ b/ens2nc/ens2nc_aq.for
@@ -497,11 +497,7 @@ C --- Here we prepare some netCDF variables of general use
 C --- Now loop on the statistics that the file might contain.
 C     We create a netCDF file for each of them
 
-      IV = USER_ITEM - 1
-
       DO IPOST = 1, SOURCE_ITEM_NPOSTS(ICODE,USER_ITEM)
-
-         IV = IV + 1
 
 C --- Open file
 
@@ -520,7 +516,7 @@ C --- Open file
          WRITE(ST1(17:18),'(I2.2)') TMP_VAR
 
          ST3 = '00'
-         WRITE(ST3(1:2),'(I2.2)') IV
+         WRITE(ST3(1:2),'(I2.2)') IPOST
          ST2 = ' '
          WRITE(ST2(1:12),'(I4.4,4I2.2)') (TMP_METEO_DATE(K),K=1,5)
          OUTPUT_B = OUTPUT_BASE(1:LSTRIM(OUTPUT_BASE))//'v'//
@@ -607,8 +603,9 @@ C     Assign units attributes to coordinate and variables.
      &            'axis',1,'X')
          IF (RETVAL .NE. NF_NOERR) CALL HANDLE_ERR(RETVAL)
          RETVAL = NF_PUT_ATT_TEXT(NCID, TIME_VARID,
-     &            'units', len(TRIM(CF_TIME_UNITS(ICODE,IV,IPOST))), 
-     &             TRIM(CF_TIME_UNITS(ICODE,IV,IPOST)))
+     &            'units',
+     &            len(TRIM(CF_TIME_UNITS(ICODE,USER_ITEM,IPOST))), 
+     &             TRIM(CF_TIME_UNITS(ICODE,USER_ITEM,IPOST)))
          IF (RETVAL .NE. NF_NOERR) CALL HANDLE_ERR(RETVAL)
          RETVAL = NF_PUT_ATT_TEXT(NCID, TIME_VARID, 
      &            'axis',1,'T')
@@ -661,27 +658,30 @@ C     Define compression level in case of NETCDF4
 
 C     Assign attributes to the netCDF variable.
          RETVAL = NF_PUT_ATT_TEXT(NCID, VARID, 
-     &            'units', len(TRIM(CF_VAR_ITEMS_UNITS(ICODE,IV))),
-     &            TRIM(CF_VAR_ITEMS_UNITS(ICODE,IV)))
+     &            'units',
+     &            len(TRIM(CF_VAR_ITEMS_UNITS(ICODE,USER_ITEM))),
+     &            TRIM(CF_VAR_ITEMS_UNITS(ICODE,USER_ITEM)))
          IF (RETVAL .NE. NF_NOERR) CALL HANDLE_ERR(RETVAL)
          RETVAL = NF_PUT_ATT_TEXT(NCID, VARID, 
      &            'long_name', 
-     &            len(TRIM(CF_VAR_ITEMS_LONG_NAME(ICODE,IV))), 
-     &            TRIM(CF_VAR_ITEMS_LONG_NAME(ICODE,IV)))
+     &            len(TRIM(CF_VAR_ITEMS_LONG_NAME(ICODE,USER_ITEM))), 
+     &            TRIM(CF_VAR_ITEMS_LONG_NAME(ICODE,USER_ITEM)))
          IF (RETVAL .NE. NF_NOERR) CALL HANDLE_ERR(RETVAL)
          RETVAL = NF_PUT_ATT_TEXT(NCID, VARID, 
      &            'standard_name', 
-     &            len(TRIM(CF_VAR_ITEMS_STANDARD_NAME(ICODE,IV))), 
-     &            TRIM(CF_VAR_ITEMS_STANDARD_NAME(ICODE,IV))) 
+     &            len(TRIM(
+     &              CF_VAR_ITEMS_STANDARD_NAME(ICODE,USER_ITEM))), 
+     &            TRIM(CF_VAR_ITEMS_STANDARD_NAME(ICODE,USER_ITEM))) 
          IF (RETVAL .NE. NF_NOERR) CALL HANDLE_ERR(RETVAL)
          RETVAL = NF_PUT_ATT_TEXT(NCID, VARID, 
      &            'canonical_units', 
-     &            len(TRIM(CF_VAR_ITEMS_CANONICAL_UNITS(ICODE,IV))), 
-     &            TRIM(CF_VAR_ITEMS_CANONICAL_UNITS(ICODE,IV)))
+     &            len(TRIM(
+     &              CF_VAR_ITEMS_CANONICAL_UNITS(ICODE,USER_ITEM))), 
+     &            TRIM(CF_VAR_ITEMS_CANONICAL_UNITS(ICODE,USER_ITEM)))
          RETVAL = NF_PUT_ATT_TEXT(NCID, VARID, 
      &            'description', 
-     &            len(TRIM(CF_VAR_ITEMS_DESCRIPTION(ICODE,IV))),
-     &            TRIM(CF_VAR_ITEMS_DESCRIPTION(ICODE,IV)))
+     &            len(TRIM(CF_VAR_ITEMS_DESCRIPTION(ICODE,USER_ITEM))),
+     &            TRIM(CF_VAR_ITEMS_DESCRIPTION(ICODE,USER_ITEM)))
          IF (RETVAL .NE. NF_NOERR) CALL HANDLE_ERR(RETVAL)
 
 C     Assign other attributes

--- a/nclib/parse_cf_averaging.for
+++ b/nclib/parse_cf_averaging.for
@@ -46,7 +46,7 @@ C
       STATISTICS  = ' '
       PERCENTILE = 0.
 
-      DO K = 1, 4
+      DO K = 1, 3
          COMMA(K) = 0
       ENDDO
 
@@ -65,27 +65,35 @@ C
 
       TIME_UNITS = STRING(2:COMMA(1)-2)
         
-      IF (STRING(COMMA(1)+1:COMMA(2)-1) .EQ. 'N') THEN
-          AVERAGING = 'N' 
-          RETURN
-      ENDIF
+      IF (I .GT. 1) THEN
 
-      IF (STRING(COMMA(1)+1:COMMA(2)-1) .EQ. 'P') THEN
-          AVERAGING = 'P'
-      ELSE
-          AVG = STRING(COMMA(1)+1:COMMA(2)-1)
-          AVG = AVG(LSTRIML(AVG):LSTRIM(AVG))
+             AVG = STRING(COMMA(1)+1:COMMA(2)-1)
+             AVG = AVG(LSTRIML(AVG):LSTRIM(AVG))
           
-          OPEN(IUNIT,STATUS='SCRATCH')
-          WRITE(IUNIT,'(A)') AVG
-          REWIND(IUNIT)
-          READ(IUNIT,*) AVERAGING
-          CLOSE(IUNIT)
+             OPEN(IUNIT,STATUS='SCRATCH')
+             WRITE(IUNIT,'(A)') AVG
+             REWIND(IUNIT)
+             READ(IUNIT,*) AVERAGING
+             CLOSE(IUNIT)
+             IF (AVERAGING(1:1) .EQ. 'N') RETURN
+
+      ELSE
+
+             AVG = STRING(COMMA(1)+1:)
+             AVG = AVG(LSTRIML(AVG):LSTRIM(AVG))
+          
+             OPEN(IUNIT,STATUS='SCRATCH')
+             WRITE(IUNIT,'(A)') AVG
+             REWIND(IUNIT)
+             READ(IUNIT,*) AVERAGING
+             CLOSE(IUNIT)
+             IF (AVERAGING(1:1) .EQ. 'N') RETURN
+
       ENDIF
+ 
+      IF (I .EQ. 1) GOTO 900
 
-      IF (I .EQ. 0) GOTO 900
-
-      IF (I .EQ. 1) THEN
+      IF (I .EQ. 2) THEN
           STS = STRING(COMMA(2)+1:)
       ELSE
           STS = STRING(COMMA(2)+1:COMMA(3)-1)
@@ -101,7 +109,7 @@ C
       ELSE IF (STS(1:3) .EQ. 'PCT') THEN
           STATISTICS = 'PCT'
           
-          IF (I .NE. 2) GOTO 900
+          IF (I .NE. 3) GOTO 900
           OPEN(IUNIT,STATUS='SCRATCH')
           WRITE(IUNIT,'(A)') STRING(COMMA(3)+1:)
           REWIND(IUNIT)

--- a/test_aq/3_3_8760.cf
+++ b/test_aq/3_3_8760.cf
@@ -39,9 +39,9 @@ CF missing_value                $ -9
 CF fill_value                   $ 
   Number of postprocessings     $ 4
   Postprocessing statistics     $ 'hours since 2010-01-01 00:0:0 0 UTC', N
-  Postprocessing statistics     $ 'days since 2010-01-01 00:0:0 0 UTC', D
-  Postprocessing statistics     $ 'days since 2010-01-01 00:0:0 0 UTC', INT
-  Postprocessing statistics     $ '', P
+  Postprocessing statistics     $ 'days since 2010-01-01 00:0:0 0 UTC', D, AVG
+  Postprocessing statistics     $ 'days since 2010-01-01 00:0:0 0 UTC', D, INT
+  Postprocessing statistics     $ '', P, INT
 #
 Comments follow                 $ N
 


### PR DESCRIPTION
compiler and when compiling with gfortran debugging compiler flags.

The changes to parse_cf_averaging.for address situations where
the string to be parsed only contains a single comma (e.g. the first
post-processing instruction in the example test_aq src and cf files).
The gfortran compiler does not seem to mind COMMA(2) to be 0 and still
be used in "STRING(COMMA(1)+1:COMMA(2)-1)" but the intel compiler will
then set the resulting string to "" which results in a read/write
error to the SCRATCH file.

The code change to  parse_cf_averaging.for also updates the loop index for K when
parsing for the position of commas (only 3 rather than 4) and increments
the value against which I (the indicator for the number of commas)
is compared by 1 when checking its value in several cases. The lower
value appears to have been inherited from 'lib/parse_averaging.for'
which has 1 less comma because the src files do not have a time
unit as part of the post-processing string

test_aq/3_3_8760.cf was updated to be consistent with test_aq/3_3_8760.src
in terms of post-processing instructions

ens2nc_aq.for was updated because the IV counter used in the original code
was incremented over the post-processing steps and was used as second dimension
in arrays that should have used the item number in that dimension. For the
gfortran compiler, this had led to missing / undefined long_name and unit
attributes in the netcdf files and for the intel compiler (and gfortran with
debug flags) led to executable crashes.

	modified:   ens2nc_aq.for
	modified:   ../nclib/parse_cf_averaging.for
	modified:   ../test_aq/3_3_8760.cf